### PR TITLE
Add Hot-Reloading for Renderer and Renderer+Main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2601,6 +2601,21 @@
         }
       }
     },
+    "@hapi/hoek": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@istanbuljs/schema": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
@@ -2906,6 +2921,27 @@
           "dev": true
         }
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -3776,6 +3812,23 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+          "dev": true
+        }
+      }
     },
     "axobject-query": {
       "version": "2.0.2",
@@ -8179,6 +8232,12 @@
         "pump": "^3.0.0"
       }
     },
+    "get-them-args": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
+      "integrity": "sha1-dKILqKSr7OWuGZrQPyvMaP38m6U=",
+      "dev": true
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -9512,6 +9571,19 @@
         }
       }
     },
+    "joi": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
+      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9998,6 +10070,16 @@
       "dev": true,
       "requires": {
         "json-buffer": "3.0.0"
+      }
+    },
+    "kill-port-process": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/kill-port-process/-/kill-port-process-2.3.0.tgz",
+      "integrity": "sha512-qINRV5WR3AgfZoqtV7PY3MMpnuptT8UtVG3TPV2ZSLf5Xb3jOj3J7FNt/2LLoqcrnm2SOoqMyN8rLs67vNqjgA==",
+      "dev": true,
+      "requires": {
+        "get-them-args": "1.3.2",
+        "pid-from-port": "1.1.3"
       }
     },
     "killable": {
@@ -12090,6 +12172,65 @@
       "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
       "dev": true
     },
+    "pid-from-port": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pid-from-port/-/pid-from-port-1.1.3.tgz",
+      "integrity": "sha512-OlE82n3yMOE5dY9RMOwxhoWefeMlxwk5IVxoj0sSzSFIlmvhN4obzTvO3s/d/b5JhcgXikjaspsy/HuUDTqbBg==",
+      "dev": true,
+      "requires": {
+        "execa": "^0.9.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+          "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
+      }
+    },
     "pidtree": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
@@ -13134,6 +13275,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "psl": {
@@ -16560,6 +16707,48 @@
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
     },
+    "wait-on": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-5.2.1.tgz",
+      "integrity": "sha512-H2F986kNWMU9hKlI9l/ppO6tN8ZSJd35yBljMLa1/vjzWP++Qh6aXyt77/u7ySJFZQqBtQxnvm/xgG48AObXcw==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.21.1",
+        "joi": "^17.3.0",
+        "lodash": "^4.17.20",
+        "minimist": "^1.2.5",
+        "rxjs": "^6.6.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "rxjs": {
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
     "watchpack": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
@@ -17397,6 +17586,58 @@
           "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
+    "webpack-electron-reload": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-electron-reload/-/webpack-electron-reload-1.0.1.tgz",
+      "integrity": "sha512-5sHtuSUEjD40A62b2floqoUr2sktiUIb6CHe/eYRD7QXcdLMDQIhdidKfA/bJl1n27awmuUKGo4VtZs8kp8xCw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.0",
   "main": "./dist/main/electron-main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "npm run start:dev:hot-reloading:renderer+main",
+    "start:dev:hot-reloading:renderer+main": "npm run build:dev:preload && npm-run-all -p hot:dev:renderer hot:dev:main",
+    "start:dev:hot-reloading:renderer-only": "npm-run-all -p build:dev:preload build:dev:main && npm-run-all -p hot:dev:renderer hot:dev:main-no-restart",
+    "start:static": "electron .",
     "build:dev:renderer": "ng build",
     "build:prod:renderer": "ng build --prod",
     "build:dev:main": "webpack --config ./src/main/webpack.ts --mode development",
@@ -24,7 +27,10 @@
     "test:lint": "ng lint",
     "test:e2e": "ng e2e",
     "package": "electron-packager . angular-electron-boilerplate --asar --overwrite --prune=true --derefSymlinks=false --ignore=\"/node_modules|/src|.vscode|.editorconfig|.gitignore|.map|angular.json|tslint.json|README.md|package-lock.json|LICENSE\" --out=release-builds",
-    "release": "npm run build:prod:all  && npm run package"
+    "release": "npm run build:prod:all  && npm run package",
+    "hot:dev:renderer": "ng serve --watch & echo Renderer shutdown",
+    "hot:dev:main": "wait-on tcp:4200 && set WEBPACK_DEV_SERVER_URL=http://localhost:4200 && webpack --watch --config ./src/main/webpack.ts --mode development",
+    "hot:dev:main-no-restart": "wait-on tcp:4200 && set WEBPACK_DEV_SERVER_URL=http://localhost:4200 && electron . & kill-port --port 4200 >NUL"
   },
   "private": true,
   "dependencies": {},
@@ -57,6 +63,7 @@
     "karma-coverage-istanbul-reporter": "~3.0.2",
     "karma-jasmine": "~3.3.0",
     "karma-jasmine-html-reporter": "^1.5.0",
+    "kill-port-process": "^2.3.0",
     "npm-run-all": "^4.1.5",
     "protractor": "~7.0.0",
     "rxjs": "~6.5.3",
@@ -65,8 +72,10 @@
     "tslib": "^2.0.0",
     "tslint": "~6.1.0",
     "typescript": "^3.9.5",
+    "wait-on": "^5.2.1",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
+    "webpack-electron-reload": "^1.0.1",
     "zone.js": "^0.11.1"
   }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import { DtoSystemInfo } from '../ipc-dtos/dtosysteminfo';
 import * as os from 'os';
 
+const BRING_WINDOW_TO_FRONT_ON_START = true;
+
 let win: BrowserWindow | null = null;
 
 app.on('ready', createWindow);
@@ -13,7 +15,7 @@ app.on('activate', () => {
   }
 });
 
-function createWindow() {
+async function createWindow(): Promise<void> {
   win = new BrowserWindow({
     width: 800,
     height: 600,
@@ -26,13 +28,34 @@ function createWindow() {
       enableRemoteModule: false,
       // Preload script
       preload: path.join(app.getAppPath(), 'dist/preload', 'preload.js')
-    }
+    },
+    show: false, // Will be made visible after page has been fully loaded for the first ime
   });
 
   // https://stackoverflow.com/a/58548866/600559
   Menu.setApplicationMenu(null);
 
-  win.loadFile(path.join(app.getAppPath(), 'dist/renderer', 'index.html'));
+  win.once("ready-to-show", () => {
+    if (win) {
+      win.show();
+      if (BRING_WINDOW_TO_FRONT_ON_START) {
+		// Prevent ugly flickering
+        setTimeout(() => {
+          win?.minimize();
+          win?.restore();
+        }, 10);
+      }
+    }
+  });
+
+  if (process.env.WEBPACK_DEV_SERVER_URL) {
+    // Load the url of the dev server if in development mode
+    await win.loadURL(process.env.WEBPACK_DEV_SERVER_URL.trim());
+  } else {
+    await win.loadFile(
+      path.join(app.getAppPath(), "dist/renderer", "index.html")
+    );
+  }
 
   win.on('closed', () => {
     win = null;

--- a/src/main/webpack.ts
+++ b/src/main/webpack.ts
@@ -1,5 +1,17 @@
 import * as path from 'path';
 
+// Add your plugins here
+let plugins: any = [];
+
+// Only require() this when we actually want to run Electron in dev mode
+// with hot-reloading.
+if (process.env.WEBPACK_DEV_SERVER_URL) {
+  const ElectronReloadPlugin = require("webpack-electron-reload")({
+    path: ".", // The directory where to watch for file changes
+  });
+  plugins.push(ElectronReloadPlugin());
+}
+
 module.exports = (env: string) => {
   if (!env) { env = 'development'; }
   return {
@@ -32,7 +44,6 @@ module.exports = (env: string) => {
       __dirname: true,
       __filename: true
     },
-    plugins: [
-    ]
+    plugins: plugins
   };
 };


### PR DESCRIPTION
I added two new scripts that are meant to be run by devs:
- start:dev:hot-reloading:renderer+main
- start:dev:hot-reloading:renderer-only

I also changed the 'start' script to default to the new
'renderer+main' script because this is probably the best user
experience while developing your application.

There are three more new scripts that are only for internal use.
Maybe these should be prefixed with an underscore or hash?

How it works
------------

Renderer:
Webpack will watch the renderer source directory and rebuild files as
needed which will also results in a hot-reload inside the Angular app.

Renderer+Main:
In addition to the behavior described above, the running Electron
process will be watched using the 'ElectronReloadPlugin' plugin.
The plugin will kill and respawn Electron whenever files in the main
source directory are changed.

In both cases Electron is launched in parallel to the rest of the
application and will wait until port 4200/TCP is open. Through
this network port Angular is able to communicate with the WDS
(Webpack Dev Server).

Depending on the selected script (Renderer or Renderer+Main),
Electron will simply launch and use the files in dist/main or
it will be killed and respawned by the reloader plugin as needed.

The implementation of the Renderer script contains a little QoL
feature which takes care of shutting down the renderer watcher
as soon as the Electron process has shutdown. Unfortunately,
this is not the case with the Renderer+Main script. The user will
have to stop the process manually (e.g. Ctrl-C) for now.