### PR TITLE
Set base href to '/' to enforce absolute paths

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -18,6 +18,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "baseHref": "/",
             "outputPath": "dist/renderer",
             "index": "src/renderer/src/index.html",
             "main": "src/renderer/src/main.ts",


### PR DESCRIPTION
This is needed so HTML sourced resources without absolute paths remain
loadable even when using routes. Otherwise, the browser would try to
request files relative to the current route like '/subpage/file.js'.

For example, this fixes loading issues with bundles that are injected
using relative (read: no) paths into the final index.html:

runtime.js, main.js, polyfills.js, etc.